### PR TITLE
Theta fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+.DS_Store
+build/.DS_Store
+build/lib/XRDXRFutils/__init__.py
+build/lib/XRDXRFutils/data.py
+build/lib/XRDXRFutils/database.py
+build/lib/XRDXRFutils/gaussnewton.py
+build/lib/XRDXRFutils/phasesearch.py
+build/lib/XRDXRFutils/spectra.py
+build/lib/XRDXRFutils/utils.py
+XRDXRFutils.egg-info/dependency_links.txt
+XRDXRFutils.egg-info/PKG-INFO
+XRDXRFutils.egg-info/SOURCES.txt
+XRDXRFutils.egg-info/top_level.txt

--- a/XRDXRFutils/database.py
+++ b/XRDXRFutils/database.py
@@ -15,7 +15,7 @@ class Phase(dict):
     def __len__(self):
         return len(self['_pd_peak_intensity'][0])
 
-    def get_theta(self,l=[1.541],scale=[1.0],max_theta=None,min_intensity=None):
+    def get_theta(self, l=[1.541], scale=[1.0], min_theta=None, max_theta=None, min_intensity=None):
 
         #FIXME
         #Recalculate when conditions are not the same
@@ -39,6 +39,8 @@ class Phase(dict):
         theta,intensity = array(sorted(zip(theta,intensity))).T
 
         f = array([True]*len(theta))
+        if min_theta:
+            f &= (theta > min_theta)
         if max_theta:
             f &= (theta < max_theta) 
         if min_intensity:

--- a/XRDXRFutils/gaussnewton.py
+++ b/XRDXRFutils/gaussnewton.py
@@ -9,7 +9,7 @@ class GaussNewton(SpectraXRD):
     """
     Class to calculate Gauss-Newton minimization of the synthetic and the experimental spectra.
     """
-    def __init__(self,phase,spectra,max_theta = 53, min_intensity = 0.05):
+    def __init__(self, phase, spectra, min_theta = 0, max_theta = 53, min_intensity = 0.05):
         """
         phase: tabulated phase; Phase or PhaseList class
         spectra: experimental spectra; Spectra class
@@ -18,6 +18,7 @@ class GaussNewton(SpectraXRD):
 
         self.label = phase.label
 
+        self.min_theta = min_theta
         self.max_theta = max_theta
         self.min_intensity = min_intensity
 
@@ -37,7 +38,7 @@ class GaussNewton(SpectraXRD):
         tabulated theta: mu
         tabulated intensity: I
         """
-        self.mu,self.I = self.get_theta(max_theta = max_theta,min_intensity = min_intensity)
+        self.mu, self.I = self.get_theta(min_theta = min_theta, max_theta = max_theta, min_intensity = min_intensity)
 
         """
         parameters sigma^2, gamma

--- a/XRDXRFutils/spectra.py
+++ b/XRDXRFutils/spectra.py
@@ -55,6 +55,19 @@ class SpectraXRD(Spectra):
 
         return self
 
+    def calibrate_from_file(self,filename):
+        """
+        Read data from file and fit the calibration curve
+
+        Calibration parameters are stored in self.opt
+
+        returns: self
+        """
+        self.calibration.from_file(filename)
+        self.opt = self.calibration.opt
+
+        return self
+
     @staticmethod
     def fce_calibration(x,a,s,beta):
         """
@@ -77,6 +90,7 @@ class SpectraXRD(Spectra):
 
     def relative_intensity(self,n=21,std=3,m=32):
         y = self.counts - self.background(n=n,std=std,m=m)
+        y[y < 0] = 0
         return y / y.max()
 
     def plot(self,*args,**kwargs):


### PR DESCRIPTION
- When calling `Phase.get_theta()` and when creating an instance of `GaussNewton`, I want to be able to select `min_theta` in addition to `max_theta`.
- I want to be able to directly calibrate a spectrum (instance of `SpectraXRD`) from file. Otherwise, I first need to create an instance of `DataXRD`, calibrate it from file and then extract the spectrum from it.
- I fixed the calculation of `SpectraXRD.relative_intensity()`, because in some cases the background can be higher than counts.