### PR TITLE
Limit the number of tabulated peaks

### DIFF
--- a/XRDXRFutils/database.py
+++ b/XRDXRFutils/database.py
@@ -15,7 +15,7 @@ class Phase(dict):
     def __len__(self):
         return len(self['_pd_peak_intensity'][0])
 
-    def get_theta(self, l=[1.541], scale=[1.0], min_theta=None, max_theta=None, min_intensity=None):
+    def get_theta(self, l=[1.541], scale=[1.0], min_theta=None, max_theta=None, min_intensity=None, first_n_peaks = None):
 
         #FIXME
         #Recalculate when conditions are not the same
@@ -23,20 +23,18 @@ class Phase(dict):
         # if hasattr(self,'theta') and hasattr(self,'intensity'):
         #     return self.theta,self.intensity
 
-        d,i = self['_pd_peak_intensity']
+        d, i = self['_pd_peak_intensity']
 
         theta = []
         intensity = []
 
-        for _l,s in zip(l,scale):
+        for _l, s in zip(l,scale):
             g = _l / (2.0 * d)
             theta += [360.0 * arcsin(g) / pi]
             intensity += [i * s]
 
         theta = concatenate(theta)
         intensity = concatenate(intensity) / 1000.0
-        
-        theta,intensity = array(sorted(zip(theta,intensity))).T
 
         f = array([True]*len(theta))
         if min_theta:
@@ -44,12 +42,14 @@ class Phase(dict):
         if max_theta:
             f &= (theta < max_theta) 
         if min_intensity:
-            f &= intensity > min_intensity
+            f &= (intensity > min_intensity)
+        theta, intensity = theta[f], intensity[f]
 
-        self.theta = theta[f]
-        self.intensity = intensity[f]
+        if first_n_peaks is not None:
+            intensity, theta = array(sorted(zip(intensity, theta), reverse = True)).T[:, 0:first_n_peaks]
 
-        return self.theta,self.intensity
+        self.theta, self.intensity = array(sorted(zip(theta, intensity))).T
+        return self.theta, self.intensity
 
     def plot(self, colors='k', linestyles='dashed', label=None, **kwargs):
 

--- a/XRDXRFutils/database.py
+++ b/XRDXRFutils/database.py
@@ -43,12 +43,13 @@ class Phase(dict):
             f &= (theta < max_theta) 
         if min_intensity:
             f &= (intensity > min_intensity)
-        theta, intensity = theta[f], intensity[f]
+        self.theta, self.intensity = theta[f], intensity[f]
 
-        if first_n_peaks is not None:
-            intensity, theta = array(sorted(zip(intensity, theta), reverse = True)).T[:, 0:first_n_peaks]
+        if (self.theta.shape[0] > 0):
+            if (first_n_peaks is not None):
+                self.intensity, self.theta = array(sorted(zip(self.intensity, self.theta), reverse = True)).T[:, 0:first_n_peaks]
+                self.theta, self.intensity = array(sorted(zip(self.theta, self.intensity))).T
 
-        self.theta, self.intensity = array(sorted(zip(theta, intensity))).T
         return self.theta, self.intensity
 
     def plot(self, colors='k', linestyles='dashed', label=None, **kwargs):

--- a/XRDXRFutils/gaussnewton.py
+++ b/XRDXRFutils/gaussnewton.py
@@ -11,7 +11,7 @@ class GaussNewton(SpectraXRD):
     """
     Class to calculate Gauss-Newton minimization of the synthetic and the experimental spectrum.
     """
-    def __init__(self, phase, spectrum, min_theta = 0, max_theta = 53, min_intensity = 0.05):
+    def __init__(self, phase, spectrum, min_theta = 0, max_theta = 53, min_intensity = 0.05, first_n_peaks = None):
         """
         phase: tabulated phase; Phase or PhaseList class
         spectrum: experimental spectrum; Spectra class
@@ -40,7 +40,7 @@ class GaussNewton(SpectraXRD):
         tabulated theta: mu
         tabulated intensity: I
         """
-        self.mu, self.I = self.get_theta(min_theta = min_theta, max_theta = max_theta, min_intensity = min_intensity)
+        self.mu, self.I = self.get_theta(min_theta = min_theta, max_theta = max_theta, min_intensity = min_intensity, first_n_peaks = None)
         self.n_peaks = self.mu.shape[0]
         # Variables along the diffraction lines
         self.mu = self.mu[newaxis, :]


### PR DESCRIPTION
In `Phase.get_theta()` it is now possible to limit the number of tabulated peaks to the first `n` highest peaks.
This feature is necessary when searching for automatic calibration, because in higher ranges of theta we find many peaks and this situation can slow down calculations.