### PR TITLE
Select calibration phase

### DIFF
--- a/XRDXRFutils/chisearch.py
+++ b/XRDXRFutils/chisearch.py
@@ -217,28 +217,28 @@ class ChiMap(GammaMap):
 
 
     def chi(self):
-        return array([phase_search.chi[0] for phase_search in self]).reshape(self.shape)
+        return array([cs.chi[0] for cs in self]).reshape(self.shape)
 
     #def opt(self):
-    #    return array([phase_search.opt for phase_search in self]).reshape(self.shape)
+    #    return array([cs.opt for cs in self]).reshape(self.shape)
 
     #def area(self):
-    #    return array([phase_search.area() for phase_search in self]).reshape(self.shape)
+    #    return array([cs.area() for cs in self]).reshape(self.shape)
 
     #def area0(self):
-    #    return array([phase_search.area0() for phase_search in self]).reshape(self.shape)
+    #    return array([cs.area0() for cs in self]).reshape(self.shape)
 
     #def overlap_area(self):
-    #    return array([phase_search.overlap_area() for phase_search in self]).reshape(self.shape)
+    #    return array([cs.overlap_area() for cs in self]).reshape(self.shape)
 
     #def L1loss(self):
-    #    return array([phase_search.L1loss() for phase_search in self]).reshape(self.shape)
+    #    return array([cs.L1loss() for cs in self]).reshape(self.shape)
 
     #def MSEloss(self):
-    #    return array([phase_search.MSEloss() for phase_search in self]).reshape(self.shape)
+    #    return array([cs.MSEloss() for cs in self]).reshape(self.shape)
 
     #def selected(self):
-    #    return array([phase_search.idx for phase_search in self]).reshape(self.shape)
+    #    return array([cs.idx for cs in self]).reshape(self.shape)
 
     #def get_index(self,x,y):
     #    return x + y * self.shape[1]

--- a/XRDXRFutils/database.py
+++ b/XRDXRFutils/database.py
@@ -17,40 +17,49 @@ class Phase(dict):
 
     def get_theta(self, l = [1.541874], scale = [1.0], min_theta = None, max_theta = None, min_intensity = None, first_n_peaks = None):
 
-        #FIXME
-        #Recalculate when conditions are not the same
-
-        if hasattr(self, 'theta') and hasattr(self, 'intensity'):
+        if (hasattr(self, 'l_last') and hasattr(self, 'scale_last') and hasattr(self, 'min_theta_last') and
+            hasattr(self, 'max_theta_last') and hasattr(self, 'min_intensity_last') and hasattr(self, 'first_n_peaks_last') and
+            l == self.l_last and scale == self.scale_last and min_theta == self.min_theta_last and
+            max_theta == self.max_theta_last and min_intensity == self.min_intensity_last and first_n_peaks == self.first_n_peaks_last and
+            hasattr(self, 'theta') and hasattr(self, 'intensity')
+        ):
             return self.theta, self.intensity
+        else:
+            self.l_last = l
+            self.scale_last = scale
+            self.min_theta_last = min_theta
+            self.max_theta_last = max_theta
+            self.min_intensity_last = min_intensity
+            self.first_n_peaks_last = first_n_peaks
 
-        d, i = self['_pd_peak_intensity']
+            d, i = self['_pd_peak_intensity']
 
-        theta = []
-        intensity = []
+            theta = []
+            intensity = []
 
-        for _l, s in zip(l,scale):
-            g = _l / (2.0 * d)
-            theta += [360.0 * arcsin(g) / pi]
-            intensity += [i * s]
+            for _l, s in zip(l,scale):
+                g = _l / (2.0 * d)
+                theta += [360.0 * arcsin(g) / pi]
+                intensity += [i * s]
 
-        theta = concatenate(theta)
-        intensity = concatenate(intensity) / 1000.0
+            theta = concatenate(theta)
+            intensity = concatenate(intensity) / 1000.0
 
-        f = array([True]*len(theta))
-        if min_theta:
-            f &= (theta > min_theta)
-        if max_theta:
-            f &= (theta < max_theta) 
-        if min_intensity:
-            f &= (intensity > min_intensity)
-        self.theta, self.intensity = theta[f], intensity[f]
+            mask = array([True]*len(theta))
+            if min_theta:
+                mask &= (theta > min_theta)
+            if max_theta:
+                mask &= (theta < max_theta) 
+            if min_intensity:
+                mask &= (intensity > min_intensity)
+            self.theta, self.intensity = theta[mask], intensity[mask]
 
-        if (self.theta.shape[0] > 0):
-            if (first_n_peaks is not None):
-                self.intensity, self.theta = array(sorted(zip(self.intensity, self.theta), reverse = True)).T[:, 0:first_n_peaks]
-                self.theta, self.intensity = array(sorted(zip(self.theta, self.intensity))).T
+            if (self.theta.shape[0] > 0):
+                if (first_n_peaks is not None):
+                    self.intensity, self.theta = array(sorted(zip(self.intensity, self.theta), reverse = True)).T[:, 0:first_n_peaks]
+                    self.theta, self.intensity = array(sorted(zip(self.theta, self.intensity))).T
 
-        return self.theta, self.intensity
+            return self.theta, self.intensity
 
 
     def set_name(self, name):
@@ -129,23 +138,14 @@ class PhaseList(list):
         else:
             return '[' + ', '.join([elem.label for elem in self]) + ']'
 
-    def get_theta(self,**kwargs):
-
-        #FIXME
-        if hasattr(self,'theta') and hasattr(self,'intensity'):
-            return self.theta,self.intensity
-        
+    def get_theta(self, **kwargs):
         theta = []
         intensity = []
-        
         for phase in self:
-            x,y = phase.get_theta(**kwargs)
-            theta += [x]
-            intensity += [y]
-            
-        self.theta,self.intensity = concatenate(theta),concatenate(intensity)
-
-        return self.theta,self.intensity
+            t, i = phase.get_theta(**kwargs)
+            theta += [t]
+            intensity += [i]
+        return concatenate(theta), concatenate(intensity)
 
 
     def set_name(self, name):

--- a/XRDXRFutils/database.py
+++ b/XRDXRFutils/database.py
@@ -123,6 +123,7 @@ class Phase(dict):
         else:
             vlines(self.theta, 0, lineheight, colors = colors, linestyles = linestyles, label = label, **kwargs)
 
+
 class PhaseList(list):
 #class PhaseList(Phase):
 
@@ -157,11 +158,12 @@ class PhaseList(list):
             phase.set_point(point)
 
 
-    def plot(self, cmap = 'tab10', **kwargs):
+    def plot(self, cmap = 'tab10', min_theta = None, max_theta = None, min_intensity = None, first_n_peaks = None, **kwargs):
         cmap_sel = cm.get_cmap(cmap)
         for i, phase in enumerate(self):
             idx_color = i % cmap_sel.N
-            phase.plot(colors = cmap_sel(idx_color), **kwargs)
+            phase.plot(min_theta = min_theta, max_theta = max_theta, min_intensity = min_intensity,
+                first_n_peaks = first_n_peaks, colors = cmap_sel(idx_color), **kwargs)
 
 
     def random(self):

--- a/XRDXRFutils/database.py
+++ b/XRDXRFutils/database.py
@@ -15,13 +15,13 @@ class Phase(dict):
     def __len__(self):
         return len(self['_pd_peak_intensity'][0])
 
-    def get_theta(self, l=[1.541874], scale=[1.0], min_theta=None, max_theta=None, min_intensity=None, first_n_peaks = None):
+    def get_theta(self, l = [1.541874], scale = [1.0], min_theta = None, max_theta = None, min_intensity = None, first_n_peaks = None):
 
         #FIXME
         #Recalculate when conditions are not the same
 
-        if hasattr(self,'theta') and hasattr(self,'intensity'):
-            return self.theta,self.intensity
+        if hasattr(self, 'theta') and hasattr(self, 'intensity'):
+            return self.theta, self.intensity
 
         d, i = self['_pd_peak_intensity']
 
@@ -100,10 +100,11 @@ class Phase(dict):
             return None
 
 
-    def plot(self, colors = 'red', linestyles = 'dashed', label = None, lineheight = None, **kwargs):
+    def plot(self, colors = 'red', linestyles = 'dashed', label = None, lineheight = None,
+         min_theta = None, max_theta = None, min_intensity = None, first_n_peaks = None, **kwargs):
 
         if not hasattr(self, 'theta'):
-            self.get_theta()
+            self.get_theta(min_theta = min_theta, max_theta = max_theta, min_intensity = min_intensity, first_n_peaks = first_n_peaks)
 
         if label is None:
             label = self.label

--- a/XRDXRFutils/gammasearch.py
+++ b/XRDXRFutils/gammasearch.py
@@ -46,8 +46,8 @@ class GammaSearch(list):
 
 
     def fit_cycle(self, **kwargs):
-        for gauss_newton in self:
-            gauss_newton.fit_cycle(**kwargs)
+        for gn in self:
+            gn.fit_cycle(**kwargs)
         return self
 
 
@@ -70,32 +70,32 @@ class GammaSearch(list):
 
 
     def area(self):
-        return array([gauss_newton.area() for gauss_newton in self])
+        return array([gn.area() for gn in self])
 
     def area0(self):
-        return array([gauss_newton.area0() for gauss_newton in self])
+        return array([gn.area0() for gn in self])
 
     def overlap(self):
-        return array([gauss_newton.overlap() for gauss_newton in self])
+        return array([gn.overlap() for gn in self])
 
     def overlap_area(self):
-        return array([gauss_newton.overlap_area() for gauss_newton in self])
+        return array([gn.overlap_area() for gn in self])
 
     def L1loss(self):
-        return array([gauss_newton.L1loss() for gauss_newton in self])
+        return array([gn.L1loss() for gn in self])
 
     def MSEloss(self):
-        return array([gauss_newton.MSEloss() for gauss_newton in self])
+        return array([gn.MSEloss() for gn in self])
 
     def overlap3_area(self):
-        return array([gauss_newton.overlap3_area() for gauss_newton in self])
+        return array([gn.overlap3_area() for gn in self])
 
     def metrics(self):
         return self.L1loss(), self.MSEloss(), self.overlap3_area()
 
 
     def overlap_total(self):
-        arr_z = array([gauss_newton.z() for gauss_newton in self])
+        arr_z = array([gn.z() for gn in self])
         z_max = arr_z.max(axis = 0)
         m = minimum(z_max, self.intensity)
         m = where(m < 0, 0, m)

--- a/XRDXRFutils/gammasearch_secondary.py
+++ b/XRDXRFutils/gammasearch_secondary.py
@@ -58,7 +58,7 @@ class GammaMap_Secondary(GammaMap):
 
 
     def overlap_area_difference(self):
-        return array([phase_search.overlap_area_difference() for phase_search in self]).reshape(self.shape)
+        return array([gs.overlap_area_difference() for gs in self]).reshape(self.shape)
 
     def overlap_area_compare(self):
-        return array([phase_search.overlap_area_compare() for phase_search in self]).reshape(self.shape)
+        return array([gs.overlap_area_compare() for gs in self]).reshape(self.shape)


### PR DESCRIPTION
Changes:
- `GammaMap.search()` accepts the new parameter `phase_selected`. If it is `None` (default), the function behaves as before, calibrating in each pixel with the phase that gives the maximum overlap; if the parameter is set to an integer value (index for the phase in GammaMap), the function calibrates everywhere with the chosen phase. To obtain this, I had to change also `GammaSearch.search()` and `GammaSearch.select()`.
- `Phase.plot()` and `PhaseList.plot()` accept the parameters that are passed to `get_theta()`.
- `Phase.get_theta()` recalculates the result when parameters are different from last call.
- `PhaseList.get_theta()` behaves in the same way. Internally, it calls `Phase.get_theta()` without storing the result.