### PR TITLE
Remove background and smooth channels

### DIFF
--- a/XRDXRFutils/__init__.py
+++ b/XRDXRFutils/__init__.py
@@ -1,9 +1,10 @@
-from .data import DataXRF, SyntheticDataXRF, DataXRD, resample, Calibration
 from .database import DatabaseXRD, Phase, PhaseList
+from .data import DataXRF, SyntheticDataXRF, DataXRD, resample, Calibration
 from .spectra import SpectraXRF, SyntheticSpectraXRF, SpectraXRD, FastSpectraXRD
-from .utils import snip, convolve, snip2d, convolve2d, snip3d, convolve3d
+from .calibration import Calibration
 from .gaussnewton import GaussNewton
 from .gammasearch import GammaSearch, GammaMap
 from .gammasearch_secondary import GammaSearch_Secondary, GammaMap_Secondary
 from .chisearch import ChiSearch, ChiMap
-from .calibration import Calibration
+from .utils import snip, convolve, snip2d, convolve2d, snip3d, convolve3d
+from .notebook_utils import *

--- a/XRDXRFutils/data.py
+++ b/XRDXRFutils/data.py
@@ -134,12 +134,10 @@ class Data():
         print('Done.')
         return self
 
-
     def smooth_channels(self, std_kernel = 0):
         print('Smoothing along channels...')
         data_smoothed = convolve3d(self.data_no_bg, n = ceil(3 * std_kernel + 1), std = std_kernel)
-        self.rescaling = nanmax(data_smoothed, axis = 2, keepdims = True)
-        self.intensity = data_smoothed / self.rescaling
+        self.intensity = data_smoothed / nanmax(data_smoothed, axis = 2, keepdims = True)
         print('Done.')
         return self
 

--- a/XRDXRFutils/database.py
+++ b/XRDXRFutils/database.py
@@ -82,7 +82,8 @@ class Phase(dict):
                 mask_peaks_selected[self.peaks_selected] = True
                 mask &= mask_peaks_selected
             self.theta, self.intensity, self.position = theta[mask], intensity[mask], position[mask]
-            self.theta, self.intensity, self.position = array(sorted(zip(self.theta, self.intensity, self.position))).T
+            if mask.sum() > 0:
+                self.theta, self.intensity, self.position = array(sorted(zip(self.theta, self.intensity, self.position))).T
 
         return self.theta.copy(), self.intensity.copy(), self.position.copy()
 

--- a/XRDXRFutils/gammasearch.py
+++ b/XRDXRFutils/gammasearch.py
@@ -44,9 +44,9 @@ class GammaSearch(list):
                 gn.opt = self.opt
 
 
-    def select(self, phase_selected):
+    def select(self, phase_selected, method = None):
         if phase_selected is None:
-            self.idx = self.overlap_area().argmax()
+            self.idx = self.phase_presence(method = method).argmax()
         else:
             self.idx = phase_selected
         self.selected = self[self.idx]
@@ -70,11 +70,12 @@ class GammaSearch(list):
         return self
 
 
-    def search(self, phase_selected = None, alpha = 1):
-        self.fit_cycle(steps = 4, gamma = True, alpha = alpha, downsample = 3)
-        self.fit_cycle(steps = 1, a = True, s = True, gamma = True, alpha = alpha, downsample = 2)
+    def search(self, phase_selected = None, method = None, alpha = 1):
+        self.fit_cycle(steps = 2, gamma = True, alpha = alpha, downsample = 3)
+        self.fit_cycle(steps = 6, a = True, s = True, gamma = True, alpha = alpha, downsample = 3)
+        self.fit_cycle(steps = 2, a = True, s = True, gamma = True, alpha = alpha, downsample = 2)
 
-        self.select(phase_selected)
+        self.select(phase_selected, method)
         self.set_opt(self.selected.opt, copy = False)
 
         self.selected.fit_cycle(steps = 2, a = True, s = True, gamma = True, alpha = alpha, downsample = 3)
@@ -286,8 +287,8 @@ class GammaMap(list):
         map.set_attributes_from(self)
         return map
 
-    def search(self, verbose = True, phase_selected = None, alpha = 1):
-        list_result = self.parallelized(verbose, self.type_of_elements.search, phase_selected = phase_selected, alpha = alpha)
+    def search(self, verbose = True, phase_selected = None, method = None, alpha = 1):
+        list_result = self.parallelized(verbose, self.type_of_elements.search, phase_selected = phase_selected, method = method, alpha = alpha)
         map = type(self)(list_result)
         map.set_attributes_from(self)
         return map

--- a/XRDXRFutils/gammasearch.py
+++ b/XRDXRFutils/gammasearch.py
@@ -46,7 +46,7 @@ class GammaSearch(list):
 
     def select(self, phase_selected, method = None):
         if phase_selected is None:
-            self.idx = self.phase_presence(method = method).argmax()
+            self.idx = self.phase_presence(method = method, correction = False).argmax()
         else:
             self.idx = phase_selected
         self.selected = self[self.idx]

--- a/XRDXRFutils/gaussnewton.py
+++ b/XRDXRFutils/gaussnewton.py
@@ -366,7 +366,8 @@ class GaussNewton(FastSpectraXRD):
         def f(self):
             z0 = clip(self.z0(), None, 1) # to avoid anomalously high peaks resulting from overlapping tabulated peaks
             z = clip(self.z(), None, 1)
-            z_stack = stack((z0, z, self.intensity))
+            intensity_corrected = maximum(self.intensity, 0)
+            z_stack = stack((z0, z, intensity_corrected))
             z_min = z_stack.min(axis = 0)
             z_max = z_stack.max(axis = 0)
             return z_min.sum() / z_max.sum()

--- a/XRDXRFutils/notebook_utils.py
+++ b/XRDXRFutils/notebook_utils.py
@@ -1,0 +1,166 @@
+from .database import Phase, PhaseList, DatabaseXRD
+from .data import DataXRF, DataXRD
+from .spectra import SpectraXRF, SpectraXRD, FastSpectraXRD
+from .calibration import Calibration
+from .gaussnewton import GaussNewton
+from .gammasearch import GammaSearch, GammaMap
+from .gammasearch_secondary import GammaSearch_Secondary, GammaMap_Secondary
+from .chisearch import ChiSearch, ChiMap
+from .utils import snip, convolve, convolve3d
+
+from os.path import isdir, exists
+from os import makedirs, remove
+from shutil import rmtree
+from pathlib import Path
+from multiprocessing import Pool
+
+import re
+import h5py
+from glob import glob
+from math import ceil
+
+from numpy import (linspace, concatenate, append, sqrt, log, sin, cos, pi, deg2rad, histogram, array,
+    unravel_index, savetxt, nan, isnan, flip, sum, average, amax, nanmax, nanmin, nanmean, nanargmax, maximum,
+    minimum, arange, empty, newaxis, stack, clip, quantile, nanquantile, ones, zeros, absolute, rot90,
+    asarray, loadtxt, where, argwhere)
+
+from pandas import DataFrame, read_csv, concat
+
+from sklearn.linear_model import LinearRegression
+from sklearn.cluster import KMeans, MiniBatchKMeans
+from scipy.optimize import curve_fit, least_squares
+from scipy.signal import find_peaks
+
+from matplotlib.pyplot import (show, close, sca, fill_between, legend, imshow, subplots, plot,
+    xlim, ylim, xlabel, ylabel, cm, title, scatter, colorbar, figure, vlines, savefig, get_cmap, hist)
+from matplotlib import rcParams
+from matplotlib.ticker import FuncFormatter, ScalarFormatter
+from matplotlib.markers import MarkerStyle
+from matplotlib.colors import BoundaryNorm
+from matplotlib.lines import Line2D
+from matplotlib.cm import get_cmap
+
+from PIL import Image
+
+
+
+def f_linear(x, a, b):
+    return a*x + b
+
+
+def f_loss(x, t, y):
+    return (x[0]*t + x[1]) - y
+
+
+def fmt(x, pos):
+    a, b = '{:.1e}'.format(x).split('e')
+    b = int(b)
+    return r'${} \times 10^{{{}}}$'.format(a, b)
+
+
+def read_raw_XRD(path_xrd, filename_scanning = 'Scanning_Parameters.txt', filename_calibration = 'calibration.ini', filename_h5 = 'xrd.h5'):
+    return (
+        DataXRD()
+        .read_params(path_xrd + filename_scanning)
+        .read(path_xrd)
+        .calibrate_from_file(path_xrd + filename_calibration)
+        .remove_background()
+        .save_h5(path_xrd + filename_h5)
+    )
+
+
+def correct_point(experimental_phases, idx_phase, gm, x, y):
+    gn = gm.get_pixel(x, y)[idx_phase]
+    phase = gn.make_phase()
+    phase.set_name('created_%d'%idx_phase)
+    phase.set_point(gm.get_index(x, y))
+    experimental_phases[idx_phase] = phase
+
+    
+def rename_phase_in_database(database, name_old, name_new):
+    for p in database[name_old]:
+        p['_chemical_name_mineral'] = name_new
+    database[name_new] = database[name_old]
+    del database[name_old]
+
+
+def find_element(element, labels, allow_loose = False):
+    for j, label in enumerate(labels):
+        if (element + '_') in label:   # search for the given string + '_' in XRF label
+            return j
+    if allow_loose:
+        for j, label in enumerate(labels):
+            if element in label:   # search for the given string in XRF label
+                return j
+    return None
+
+
+def settings_lims(ax, x_min, x_max, y_min, y_max):
+    if (x_min is not None):
+        x_min -= 0.5
+    if (x_max is not None):
+        x_max += 0.5
+    if (y_min is not None):
+        y_min -= 0.5
+    if (y_max is not None):
+        y_max += 0.5
+    ax.set_xlim(x_min, x_max)
+    ax.set_ylim(y_min, y_max)
+
+
+def settings_plot(im, ax, x_min, x_max, y_min, y_max, position_colorbar, label_colorbar = None, powerlimits = None):
+    settings_lims(ax, x_min, x_max, y_min, y_max)
+    if (powerlimits is not None):
+        formatter = ScalarFormatter(useMathText = True)
+        formatter.set_scientific(True)
+        formatter.set_powerlimits(powerlimits)
+        cb = colorbar(im, ax = ax, cax = ax.inset_axes(position_colorbar), format = formatter)
+        cb.ax.yaxis.set_offset_position('left')
+    else:
+        cb = colorbar(im, ax = ax, cax = ax.inset_axes(position_colorbar))
+    if (label_colorbar is not None):
+        cb.set_label(label_colorbar)
+
+
+def phases_from_file(filename, database):
+    phases = []
+    df = read_csv(filename, header = None)
+    
+    for i in range(df.shape[0]):
+        name = df.iloc[i][0]
+        index_sample = df.iloc[i][2]
+        if name in database.keys():
+            phase = database[name][index_sample]
+            phase.set_label(f'{name} {index_sample}')
+            phases.append(phase)
+        else:
+            print(f'Could not find phase \'{name}\' in the database.')
+
+    print('Loaded phases: ' + ', '.join([p.label for p in phases]))
+    return phases
+
+
+def is_element_in_formula(element, formula):
+    if element == '':
+        return False
+    else:
+        return re.search(element + '[\d\s]|' + element + '$', formula)
+
+
+def clean_phase_name(name):
+    name_clean = name
+    for c in ['/', '\\']:
+        name_clean = name_clean.replace(c, '_')
+    return name_clean
+
+def shorten_string(s, length_max):
+    if len(s) > length_max:
+        s_short = s[:(length_max - 3)] + '...'
+    else:
+        s_short = s
+    return s_short
+
+
+rcParams.update({
+    'image.origin': 'lower'
+})

--- a/XRDXRFutils/spectra.py
+++ b/XRDXRFutils/spectra.py
@@ -1,4 +1,4 @@
-from numpy import loadtxt, arctan, pi, arange, array, asarray, linspace, zeros, maximum
+from numpy import loadtxt, arctan, pi, arange, array, asarray, linspace, zeros, maximum, nanmax, where
 from math import ceil
 from matplotlib.pyplot import plot
 import xml.etree.ElementTree as et
@@ -241,14 +241,19 @@ class SpectraXRD(Spectra):
         )
 
 
-    def background_elimination_and_smoothing(self, n_snip = 21, std_snip = 3, window_snip = 32, offset_background = 0, std_smooth = 0, avoid_negative = False):
-        background = snip(convolve(self.counts, n = n_snip, std = std_snip), m = window_snip)
-        self.background_shifted = background + offset_background
-        counts_no_bg = self.counts - self.background_shifted
-        if avoid_negative:
-            counts_no_bg = maximum(counts_no_bg, 0)
-        self.counts_smoothed = convolve(counts_no_bg, n = ceil(3 * std_smooth + 1), std = std_smooth)
-        self.rescaling = self.counts_smoothed.max()
+    def remove_background(self, std_kernel = 3, window_snip = 32, offset_background = 0):
+        self.background = snip(convolve(self.counts, n = ceil(3 * std_kernel + 1), std = std_kernel), m = window_snip)
+        self.offset_background = offset_background
+        self.counts_no_bg = self.counts - self.background
+        self.counts_no_bg = where(self.counts_no_bg > offset_background, self.counts_no_bg, 0)
+        self.rescaling = nanmax(self.counts_no_bg)
+        self.calculate_downsampled_intensity(self.counts_no_bg / self.rescaling)
+        return self
+
+
+    def smooth_channels(self, std_kernel = 0):
+        self.counts_smoothed = convolve(self.counts_no_bg, n = ceil(3 * std_kernel + 1), std = std_kernel)
+        self.rescaling = nanmax(self.counts_smoothed)
         self.calculate_downsampled_intensity(self.counts_smoothed / self.rescaling)
         return self
 


### PR DESCRIPTION
# What's new

### Remove background and smooth channels
These two steps of data processing are meant to be performed by two separate methods: `remove_background()` and `smooth_channels()`. They are now implemented in classes `Data`, `Spectra` and `SpectraXRD`.

Also, the implementation of `offset_background` has slightly changed. Instead of rising the level of background (which would affect in uneven ways different peaks, giving more ratio of reduction in small peaks), we now set to 0 all the values between `background` and `offset_background`.

### Phase search
It is now possible to select the method to quantify phase presence, to be used in `GammaMap.search()` and passed down to `GammaSearch.search()`, `GammaSearch.select()` and `GaussNewton.phase_presence()`.

### notebook_utils
Added module `notebook_utils`, that contains all the imports and functions used in analysis notebooks.

### Other
In class `Phase`, the method `get_theta()` now correctly deals with the case when 0 peaks are selected by the given conditions.